### PR TITLE
Move SSH compliance policies to JSON format

### DIFF
--- a/bin/ssh_scan
+++ b/bin/ssh_scan
@@ -18,7 +18,8 @@ end
 # Populate the info we need to perform a scan
 ip = ARGV[0].chomp
 port = ARGV[1].nil? ? 22 : ARGV[1].to_i
-policy = SSHScan::IntermediatePolicy.new
+
+policy = SSHScan::Policy.from_file(File.expand_path("../../policies/mozilla_intermediate.yml", __FILE__))
 
 # Perform scan and get results
 scan_engine = SSHScan::ScanEngine.new()

--- a/lib/ssh_scan/scan_engine.rb
+++ b/lib/ssh_scan/scan_engine.rb
@@ -27,7 +27,6 @@ module SSHScan
       result.merge!(kex_init_response.to_hash)
 
       # Evaluate for Policy Compliance
-      policy = SSHScan::IntermediatePolicy.new
       policy_mgr = SSHScan::PolicyManager.new(result, policy)
       result['compliance'] = policy_mgr.compliance_results
 

--- a/policies/mozilla_intermediate.yml
+++ b/policies/mozilla_intermediate.yml
@@ -1,0 +1,14 @@
+---
+name: Mozilla Intermediate
+kex:
+- diffie-hellman-group-exchange-sha256
+encryption:
+- aes256-ctr
+- aes192-ctr
+- aes128-ctr
+macs:
+- hmac-sha2-512
+- hmac-sha2-256
+compression:
+- none
+- zlib@openssh.com

--- a/policies/mozilla_modern.yml
+++ b/policies/mozilla_modern.yml
@@ -1,0 +1,25 @@
+---
+name: Mozilla Intermediate
+kex:
+- curve25519-sha256@libssh.org
+- ecdh-sha2-nistp521
+- ecdh-sha2-nistp384
+- ecdh-sha2-nistp256
+- diffie-hellman-group-exchange-sha256
+encryption:
+- chacha20-poly1305@openssh.com
+- aes256-gcm@openssh.com
+- aes128-gcm@openssh.com
+- aes256-ctr
+- aes192-ctr
+- aes128-ctr
+macs:
+- hmac-sha2-512-etm@openssh.com
+- hmac-sha2-256-etm@openssh.com
+- umac-128-etm@openssh.com
+- hmac-sha2-512
+- hmac-sha2-256
+- umac-128@openssh.com
+compression:
+- none
+- zlib@openssh.com


### PR DESCRIPTION
First stab at addressing #9 in an effort to make policy management more portable and easier to edit.