### PR TITLE
Add policies to gem

### DIFF
--- a/ssh_scan.gemspec
+++ b/ssh_scan.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.files = Dir.glob("lib/**/*") +
             Dir.glob("bin/**/*") +
+            Dir.glob("policies/**/*") +
             [".gitignore",
              ".rspec",
              ".travis.yml",


### PR DESCRIPTION
When running ssh_scan from gem install the policies were not being shipped with the gem, resulting in the following error...

    $ ssh_scan 192.168.10.186
    /Users/jclaudius/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/psych.rb:464:in `initialize': No such file or directory @ rb_sysopen - /Users/jclaudius/.rvm/gems/ruby-2.2.3/gems/ssh_scan-0.0.3/policies/mozilla_modern.yml (Errno::ENOENT)
    	from /Users/jclaudius/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/psych.rb:464:in `open'
    	from /Users/jclaudius/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/psych.rb:464:in `load_file'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/gems/ssh_scan-0.0.3/lib/ssh_scan/policy.rb:16:in `from_file'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/gems/ssh_scan-0.0.3/bin/ssh_scan:22:in `<top (required)>'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/bin/ssh_scan:23:in `load'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/bin/ssh_scan:23:in `<main>'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
    	from /Users/jclaudius/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'

This patch adds policies to the gem container to address this issue.